### PR TITLE
Time scale instead of sleep

### DIFF
--- a/QSB/TimeSync/WakeUpSync.cs
+++ b/QSB/TimeSync/WakeUpSync.cs
@@ -142,9 +142,10 @@ namespace QSB.TimeSync
                 return;
             }
             DebugLog.Screen("Starting sleeping");
-            var wakePrompt = _campfire.GetValue<ScreenPrompt>("_wakePrompt");
-            Locator.GetPromptManager().RemoveScreenPrompt(wakePrompt, PromptPosition.Center);
-            _campfire.Invoke("StartSleeping");
+            //var wakePrompt = _campfire.GetValue<ScreenPrompt>("_wakePrompt");
+            //Locator.GetPromptManager().RemoveScreenPrompt(wakePrompt, PromptPosition.Center);
+            //_campfire.Invoke("StartSleeping");
+            Time.timeScale = 10f;
             _state = State.Sleeping;
         }
 
@@ -155,7 +156,8 @@ namespace QSB.TimeSync
                 return;
             }
             DebugLog.Screen("Stopping sleeping");
-            _campfire.StopSleeping();
+            //_campfire.StopSleeping();
+            Time.timeScale = 1f;
             _state = State.Awake;
         }
 
@@ -165,7 +167,7 @@ namespace QSB.TimeSync
             {
                 return;
             }
-            OWTime.Pause(OWTime.PauseType.Menu);
+            //OWTime.Pause(OWTime.PauseType.Menu);
             Time.timeScale = 0f;
             _state = State.Pausing;
         }
@@ -176,7 +178,8 @@ namespace QSB.TimeSync
             {
                 return;
             }
-            OWTime.Unpause(OWTime.PauseType.Menu);
+            //OWTime.Unpause(OWTime.PauseType.Menu);
+            Time.timeScale = 1f;
             _state = State.Awake;
         }
 

--- a/QSB/TimeSync/WakeUpSync.cs
+++ b/QSB/TimeSync/WakeUpSync.cs
@@ -20,6 +20,7 @@ namespace QSB.TimeSync
         private float _sendTimer;
         private float _serverTime;
         private float _timeScale;
+        private bool _isInputDisabled;
 
         private void Start()
         {
@@ -104,6 +105,7 @@ namespace QSB.TimeSync
             {
                 DebugLog.Screen($"My time ({myTime}) is {-diff} behind server ({_serverTime})");
                 StartFastForwarding();
+                DisableInput();
                 return;
             }
         }
@@ -156,6 +158,23 @@ namespace QSB.TimeSync
         {
             _timeScale = 1f;
             _state = State.Awake;
+
+            if (_isInputDisabled)
+            {
+                EnableInput();
+            }
+        }
+
+        private void DisableInput()
+        {
+            _isInputDisabled = true;
+            OWInput.ChangeInputMode(InputMode.None);
+        }
+
+        private void EnableInput()
+        {
+            _isInputDisabled = false;
+            OWInput.ChangeInputMode(InputMode.Character);
         }
 
         private void Update()

--- a/QSB/TimeSync/WakeUpSync.cs
+++ b/QSB/TimeSync/WakeUpSync.cs
@@ -89,6 +89,11 @@ namespace QSB.TimeSync
             {
                 OpenEyes();
                 _state = State.Awake;
+
+                if (!isServer)
+                {
+                    DisableInput();
+                }
             }
 
             var myTime = Time.timeSinceLevelLoad;
@@ -96,16 +101,13 @@ namespace QSB.TimeSync
 
             if (diff > TimeThreshold)
             {
-                DebugLog.Screen($"My time ({myTime}) is {diff} ahead server ({_serverTime})");
                 StartPausing();
                 return;
             }
 
             if (diff < -TimeThreshold)
             {
-                DebugLog.Screen($"My time ({myTime}) is {-diff} behind server ({_serverTime})");
                 StartFastForwarding();
-                DisableInput();
                 return;
             }
         }
@@ -127,11 +129,6 @@ namespace QSB.TimeSync
             Locator.GetPromptManager().RemoveScreenPrompt(cameraEffectController.GetValue<ScreenPrompt>("_wakePrompt"));
             OWTime.Unpause(OWTime.PauseType.Sleeping);
             cameraEffectController.Invoke("WakeUp");
-
-            // Enable all inputs immediately.
-            OWInput.ChangeInputMode(InputMode.Character);
-            typeof(OWInput).SetValue("_inputFadeFraction", 0f);
-            GlobalMessenger.FireEvent("TakeFirstFlashbackSnapshot");
         }
 
         private void StartFastForwarding()
@@ -222,6 +219,11 @@ namespace QSB.TimeSync
             }
 
             Time.timeScale = _timeScale;
+
+            if (_isInputDisabled && OWInput.GetInputMode() != InputMode.None)
+            {
+                DisableInput();
+            }
         }
 
     }

--- a/QSB/TimeSync/WakeUpSync.cs
+++ b/QSB/TimeSync/WakeUpSync.cs
@@ -20,7 +20,7 @@ namespace QSB.TimeSync
         private float _sendTimer;
         private float _serverTime;
         private float _timeScale;
-        private bool _isInputDisabled;
+        private bool _isInputEnabled = true;
 
         private void Start()
         {
@@ -156,7 +156,7 @@ namespace QSB.TimeSync
             _timeScale = 1f;
             _state = State.Awake;
 
-            if (_isInputDisabled)
+            if (!_isInputEnabled)
             {
                 EnableInput();
             }
@@ -164,13 +164,13 @@ namespace QSB.TimeSync
 
         private void DisableInput()
         {
-            _isInputDisabled = true;
+            _isInputEnabled = false;
             OWInput.ChangeInputMode(InputMode.None);
         }
 
         private void EnableInput()
         {
-            _isInputDisabled = false;
+            _isInputEnabled = true;
             OWInput.ChangeInputMode(InputMode.Character);
         }
 
@@ -220,7 +220,7 @@ namespace QSB.TimeSync
 
             Time.timeScale = _timeScale;
 
-            if (_isInputDisabled && OWInput.GetInputMode() != InputMode.None)
+            if (!_isInputEnabled && OWInput.GetInputMode() != InputMode.None)
             {
                 DisableInput();
             }


### PR DESCRIPTION
My solution to this is to go back to the dirty way I was forcing time scale before, by setting it on every update.

This is because otherwise the client could reset the time scale to 1 by pausing and unpausing, and maybe by some other mechanism that we don't know about? This way we know for sure that the time scale will always be what it should.

`StopSleeping` and `StopPausing` have been merged into a single `ResetTimeScale`, since they would now both do the same thing.

If the client connects after the server, it will fast forward with inputs disabled. If fast forward happens in any other scenario, inputs will remain enabled. This means that if the client somehow becomes very out of sync, behind the server, it's possible to play the game in fast-forward mode. I think that's a good thing, since it means you retain *some* control if the games get out of sync.