### PR TITLE
Sync game state on connect

### DIFF
--- a/QSB/Events/FullStateMessage.cs
+++ b/QSB/Events/FullStateMessage.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using QSB.Messaging;
+using UnityEngine.Networking;
+
+namespace QSB.Events
+{
+    class FullStateMessage : NameMessage
+    {
+        public override MessageType MessageType => MessageType.FullState;
+
+        public Dictionary<uint, string> PlayerNames;
+
+        public override void Deserialize(NetworkReader reader)
+        {
+            base.Deserialize(reader);
+            PlayerNames = new Dictionary<uint, string>();
+
+            reader.ReadString().Split(',').ToList().ForEach(pair =>
+            {
+                var splitPair = pair.Split(':');
+                var key = Convert.ToUInt16(splitPair[0]);
+                var value = splitPair[1];
+                PlayerNames[key] = value;
+            });
+        }
+
+        public override void Serialize(NetworkWriter writer)
+        {
+            base.Serialize(writer);
+
+            var playerNamePairs = PlayerNames.ToList().Select(pair => $"{pair.Key}:{pair.Value}").ToArray();
+
+            writer.Write(string.Join(",", playerNamePairs));
+        }
+    }
+}

--- a/QSB/Events/GameState.cs
+++ b/QSB/Events/GameState.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using QSB.Messaging;
+using QSB.TransformSync;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace QSB.Events
+{
+    class GameState : NetworkBehaviour
+    {
+        private MessageHandler<FullStateMessage> _messageHandler;
+
+        private void Awake()
+        {
+            _messageHandler = new MessageHandler<FullStateMessage>();
+            _messageHandler.OnClientReceiveMessage += OnClientReceiveMessage;
+            _messageHandler.OnServerReceiveMessage += OnServerReceiveMessage;
+        }
+
+        private void OnServerReceiveMessage(FullStateMessage message)
+        {
+            _messageHandler.SendToAll(message);
+        }
+
+        private void OnClientReceiveMessage(FullStateMessage message)
+        {
+            PlayerJoin.PlayerNames = message.PlayerNames;
+        }
+    }
+}

--- a/QSB/Events/GameState.cs
+++ b/QSB/Events/GameState.cs
@@ -15,17 +15,21 @@ namespace QSB.Events
         {
             _messageHandler = new MessageHandler<FullStateMessage>();
             _messageHandler.OnClientReceiveMessage += OnClientReceiveMessage;
-            _messageHandler.OnServerReceiveMessage += OnServerReceiveMessage;
-        }
-
-        private void OnServerReceiveMessage(FullStateMessage message)
-        {
-            _messageHandler.SendToAll(message);
         }
 
         private void OnClientReceiveMessage(FullStateMessage message)
         {
             PlayerJoin.PlayerNames = message.PlayerNames;
+        }
+
+        public void Send()
+        {
+            var message = new FullStateMessage()
+            {
+                PlayerNames = PlayerJoin.PlayerNames
+            };
+
+            _messageHandler.SendToAll(message);
         }
     }
 }

--- a/QSB/Events/PlayerJoin.cs
+++ b/QSB/Events/PlayerJoin.cs
@@ -9,7 +9,7 @@ namespace QSB.Events
 {
     public class PlayerJoin : NetworkBehaviour
     {
-        public static readonly Dictionary<uint, string> PlayerNames = new Dictionary<uint, string>();
+        public static Dictionary<uint, string> PlayerNames = new Dictionary<uint, string>();
         public static string MyName { get; private set; }
 
         private MessageHandler<JoinMessage> _joinHandler;

--- a/QSB/Messaging/MessageType.cs
+++ b/QSB/Messaging/MessageType.cs
@@ -9,7 +9,8 @@ namespace QSB.Messaging
         AnimTrigger = MsgType.Highest + 3,
         Join = MsgType.Highest + 4,
         Death = MsgType.Highest + 5,
-        Leave = MsgType.Highest + 6
+        Leave = MsgType.Highest + 6,
+        FullState = MsgType.Highest + 7
         // Add other message types here, incrementing the value.
     }
 }

--- a/QSB/QSB.csproj
+++ b/QSB/QSB.csproj
@@ -107,6 +107,8 @@
     <Compile Include="Animation\AnimTriggerMessage.cs" />
     <Compile Include="Animation\AnimTrigger.cs" />
     <Compile Include="DebugActions.cs" />
+    <Compile Include="Events\FullStateMessage.cs" />
+    <Compile Include="Events\GameState.cs" />
     <Compile Include="Events\Necronomicon.cs" />
     <Compile Include="Events\JoinMessage.cs" />
     <Compile Include="Events\LeaveMessage.cs" />

--- a/QSB/QSBNetworkManager.cs
+++ b/QSB/QSBNetworkManager.cs
@@ -96,19 +96,25 @@ namespace QSB
             base.OnServerAddPlayer(conn, playerControllerId);
 
             NetworkServer.SpawnWithClientAuthority(Instantiate(_shipPrefab), conn);
+
+            var gameState = gameObject.AddComponent<GameState>();
+            gameState.Send();
         }
 
         public override void OnClientConnect(NetworkConnection conn)
         {
             base.OnClientConnect(conn);
 
-            DebugLog.Screen("OnClientConnect");
             gameObject.AddComponent<SectorSync>();
             gameObject.AddComponent<PlayerJoin>().Join(_playerName);
             gameObject.AddComponent<PlayerLeave>();
             gameObject.AddComponent<RespawnOnDeath>();
             gameObject.AddComponent<PreventShipDestruction>();
-            gameObject.AddComponent<GameState>();
+
+            if (!Network.isServer)
+            {
+                gameObject.AddComponent<GameState>();
+            }
 
             _canEditName = false;
 

--- a/QSB/QSBNetworkManager.cs
+++ b/QSB/QSBNetworkManager.cs
@@ -108,6 +108,7 @@ namespace QSB
             gameObject.AddComponent<PlayerLeave>();
             gameObject.AddComponent<RespawnOnDeath>();
             gameObject.AddComponent<PreventShipDestruction>();
+            gameObject.AddComponent<GameState>();
 
             _canEditName = false;
 


### PR DESCRIPTION
https://github.com/Raicuparta/quantum-space-buddies/pull/86/files
This is to set up the structure of syncing the full game state when a player connects. Only syncs player names now, but it would include the suit state, any solar system syncing we do eventually (time, doors, other shared objects, etc).

The way I see it, there are two ways we could do this:
* The way I'm already doing it, which is having this GameState behaviour that sends and receives messages, and then updates the needed variables everywhere. So for the names, GameState will modify the dictionary in PlayerJoin.
* Have the full state of the game centralized in GameState. So the player names dictionary would move to GameState, along with every other piece of information that needs to be synced.

I went with the first one because it means less code changes right now. But the second way might make things easier to manage in the long run, instead of having the game state spread out everywhere.

For each player's state, instead of having a bunch of dictionaries everywhere, we could have one dictionary in GameState like `<id, PlayerState>`, where PlayerState has all the syncable variables like sector, suit state, name, etc.

Either way we decide to go, I would still merge this one first, and then slowly move everything else if needed.