### PR TITLE
proper teleportation + some refactoring

### DIFF
--- a/QSB/Events/EventListener.cs
+++ b/QSB/Events/EventListener.cs
@@ -79,7 +79,6 @@ namespace QSB.Events
                     break;
                 case EventType.RetrieveProbe:
                     player.UpdateState(State.ProbeActive, false);
-                    player.Probe.Reset();
                     break;
                 case EventType.LaunchProbe:
                     player.UpdateState(State.ProbeActive, true);

--- a/QSB/Events/EventListener.cs
+++ b/QSB/Events/EventListener.cs
@@ -79,9 +79,11 @@ namespace QSB.Events
                     break;
                 case EventType.RetrieveProbe:
                     player.UpdateState(State.ProbeActive, false);
+                    player.Probe.Reset();
                     break;
                 case EventType.LaunchProbe:
                     player.UpdateState(State.ProbeActive, true);
+                    player.Probe.Reset();
                     break;
             }
         }

--- a/QSB/PlayerInfo.cs
+++ b/QSB/PlayerInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using QSB.Tools;
+using QSB.TransformSync;
 using QSB.Utility;
 using UnityEngine;
 
@@ -9,8 +10,8 @@ namespace QSB
     {
         public uint NetId { get; }
         public GameObject Body { get; set; }
+        public Vector3 Position => Body.transform.position;
         public GameObject Camera { get; set; }
-        public GameObject ProbeBody { get; set; }
         public QSBProbe Probe { get; set; }
         public QSBFlashlight FlashLight => Camera.GetComponentInChildren<QSBFlashlight>();
         public QSBTool Signalscope => GetToolByType(ToolType.Signalscope);
@@ -19,6 +20,8 @@ namespace QSB
         public string Name { get; set; }
         public bool IsReady { get; set; }
         public State State { get; private set; }
+        public PlayerTransformSync PlayerTransformSync { get; set; }
+        public Transform ReferenceTransform => PlayerTransformSync.ReferenceTransform;
 
         public PlayerInfo(uint id)
         {

--- a/QSB/QSB.csproj.user
+++ b/QSB/QSB.csproj.user
@@ -1,10 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <GameDir>C:\Program Files\Epic Games\OuterWilds</GameDir>
-    <OwmlDir>C:\Users\Alek\Documents\Source\OWML\Release</OwmlDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <StartWorkingDirectory>C:\Program Files\Epic Games\OuterWilds\OuterWilds_Data\Managed\</StartWorkingDirectory>
+    <GameDir>D:/EpicGames/OuterWilds</GameDir>
+    <OwmlDir>C:\Users\Henry\Downloads\OWModManager\OWML</OwmlDir>
   </PropertyGroup>
 </Project>

--- a/QSB/Tools/PlayerToolsManager.cs
+++ b/QSB/Tools/PlayerToolsManager.cs
@@ -41,13 +41,6 @@ namespace QSB.Tools
             }
         }
 
-        public static void CreateProbe(Transform body, uint id)
-        {
-            var newProbe = body.gameObject.AddComponent<QSBProbe>();
-            newProbe.Init(id);
-
-            PlayerRegistry.GetPlayer(id).Probe = newProbe;
-        }
 
         private static void CreateStowTransforms()
         {

--- a/QSB/Tools/PlayerToolsManager.cs
+++ b/QSB/Tools/PlayerToolsManager.cs
@@ -184,4 +184,3 @@ namespace QSB.Tools
         }
     }
 }
--

--- a/QSB/Tools/QSBProbe.cs
+++ b/QSB/Tools/QSBProbe.cs
@@ -29,13 +29,12 @@ namespace QSB.Tools
         public void Deactivate()
         {
             DebugLog.ToConsole($"Deactivating {_player.Name}'s probe.", MessageType.Info);
-            Reset();
             gameObject.SetActive(false);
         }
 
         public void Reset()
         {
-            var position = _player.ProbeLauncher.ToolGameObject.transform.position;
+            var position = _player.ProbeLauncher.ToolGameObject.transform.localPosition;
             _probeSync.TeleportTo(position, _player.ReferenceTransform);
         }
     }

--- a/QSB/Tools/QSBProbe.cs
+++ b/QSB/Tools/QSBProbe.cs
@@ -19,11 +19,6 @@ namespace QSB.Tools
             _probeSync = playerProbeSync;
         }
 
-        private void Start()
-        {
-            gameObject.SetActive(false);
-        }
-
         public void Activate()
         {
             DebugLog.ToConsole($"Activating {_player.Name}'s probe.", MessageType.Info);
@@ -40,7 +35,8 @@ namespace QSB.Tools
 
         public void Reset()
         {
-            _probeSync.TeleportToPlayer(_player);
+            var position = _player.ProbeLauncher.ToolGameObject.transform.position;
+            _probeSync.TeleportTo(position, _player.ReferenceTransform);
         }
     }
 }

--- a/QSB/Tools/QSBProbe.cs
+++ b/QSB/Tools/QSBProbe.cs
@@ -34,7 +34,7 @@ namespace QSB.Tools
 
         public void Reset()
         {
-            var position = _player.ProbeLauncher.ToolGameObject.transform.localPosition;
+            var position = _player.ProbeLauncher.ToolGameObject.transform.position;
             _probeSync.TeleportTo(position, _player.ReferenceTransform);
         }
     }

--- a/QSB/Tools/QSBProbe.cs
+++ b/QSB/Tools/QSBProbe.cs
@@ -22,14 +22,14 @@ namespace QSB.Tools
         public void Activate()
         {
             DebugLog.ToConsole($"Activating {_player.Name}'s probe.", MessageType.Info);
-            gameObject.SetActive(true);
+            Body.SetActive(true);
             Reset();
         }
 
         public void Deactivate()
         {
             DebugLog.ToConsole($"Deactivating {_player.Name}'s probe.", MessageType.Info);
-            gameObject.SetActive(false);
+            Body.SetActive(false);
         }
 
         public void Reset()

--- a/QSB/Tools/QSBProbe.cs
+++ b/QSB/Tools/QSBProbe.cs
@@ -1,4 +1,5 @@
 ﻿using OWML.Common;
+using QSB.TransformSync;
 using QSB.Utility;
 using UnityEngine;
 
@@ -6,28 +7,40 @@ namespace QSB.Tools
 {
     public class QSBProbe : MonoBehaviour
     {
-        private uint _attachedNetId;
+        public GameObject Body { get; private set; }
 
-        public void Init(uint netid)
+        private PlayerInfo _player;
+        private PlayerProbeSync _probeSync;
+
+        public void Init(GameObject body, PlayerInfo player,  PlayerProbeSync playerProbeSync)
         {
-            _attachedNetId = netid;
+            Body = body;
+            _player = player;
+            _probeSync = playerProbeSync;
         }
 
-        void Start()
+        private void Start()
         {
             gameObject.SetActive(false);
         }
 
         public void Activate()
         {
-            DebugLog.ToConsole($"Activating player {_attachedNetId}'s probe.", MessageType.Info);
+            DebugLog.ToConsole($"Activating {_player.Name}'s probe.", MessageType.Info);
             gameObject.SetActive(true);
+            Reset();
         }
 
         public void Deactivate()
         {
-            DebugLog.ToConsole($"Deactivating player {_attachedNetId}'s probe.", MessageType.Info);
+            DebugLog.ToConsole($"Deactivating {_player.Name}'s probe.", MessageType.Info);
+            Reset();
             gameObject.SetActive(false);
+        }
+
+        public void Reset()
+        {
+            _probeSync.TeleportToPlayer(_player);
         }
     }
 }

--- a/QSB/TransformSync/PlayerCameraSync.cs
+++ b/QSB/TransformSync/PlayerCameraSync.cs
@@ -46,11 +46,6 @@ namespace QSB.TransformSync
             return body.transform;
         }
 
-        protected override Vector3? Override()
-        {
-            return null;
-        }
-
         protected override bool IsReady()
         {
             return Locator.GetPlayerTransform() != null && PlayerRegistry.PlayerExists(GetAttachedNetId());

--- a/QSB/TransformSync/PlayerCameraSync.cs
+++ b/QSB/TransformSync/PlayerCameraSync.cs
@@ -12,17 +12,7 @@ namespace QSB.TransformSync
             LocalInstance = this;
         }
 
-        protected override uint GetAttachedNetId()
-        { 
-            /*
-            Players are stored in PlayerRegistry using a specific ID. This ID has to remain the same
-            for all components of a player, so I've chosen to used the netId of PlayerTransformSync.
-            Since every networkbehaviour has it's own ascending netId, and we know that PlayerCameraSync
-            is the 3rd network transform to be loaded (After PlayerTransformSync and ShipTransformSync),
-            we can just minus 2 from PlayerCameraSync's netId to get PlayerTransformSyncs's netId.
-            */
-            return netId.Value - 2;
-        }
+        protected override uint PlayerId => netId.Value - 2;
 
         protected override Transform InitLocalTransform()
         {
@@ -30,7 +20,7 @@ namespace QSB.TransformSync
 
             PlayerToolsManager.Init(body);
 
-            PlayerRegistry.GetPlayer(GetAttachedNetId()).Camera = body.gameObject;
+            Player.Camera = body.gameObject;
 
             return body;
         }
@@ -41,14 +31,14 @@ namespace QSB.TransformSync
 
             PlayerToolsManager.Init(body.transform);
 
-            PlayerRegistry.GetPlayer(GetAttachedNetId()).Camera = body;
+            Player.Camera = body;
 
             return body.transform;
         }
 
         protected override bool IsReady()
         {
-            return Locator.GetPlayerTransform() != null && PlayerRegistry.PlayerExists(GetAttachedNetId());
+            return Locator.GetPlayerTransform() != null && Player != null;
         }
     }
 }

--- a/QSB/TransformSync/PlayerProbeSync.cs
+++ b/QSB/TransformSync/PlayerProbeSync.cs
@@ -30,6 +30,7 @@ namespace QSB.TransformSync
         {
             var body = Instantiate(GetProbe());
             Player.Probe = CreateProbe(body.gameObject, Player);
+            Player.Probe.gameObject.SetActive(false);
             return body;
         }
 

--- a/QSB/TransformSync/PlayerProbeSync.cs
+++ b/QSB/TransformSync/PlayerProbeSync.cs
@@ -55,16 +55,6 @@ namespace QSB.TransformSync
             return body;
         }
 
-        protected override Vector3? Override()
-        {
-            var player = PlayerRegistry.GetPlayer(GetAttachedNetId());
-            if (player.GetState(State.ProbeActive))
-            {
-                return null;
-            }
-            return PlayerRegistry.GetPlayer(GetAttachedNetId()).ProbeLauncher.transform.position;
-        }
-
         protected override bool IsReady()
         {
             return Locator.GetProbe() != null && PlayerRegistry.PlayerExists(GetAttachedNetId());

--- a/QSB/TransformSync/PlayerProbeSync.cs
+++ b/QSB/TransformSync/PlayerProbeSync.cs
@@ -30,7 +30,7 @@ namespace QSB.TransformSync
         {
             var body = Instantiate(GetProbe());
             Player.Probe = CreateProbe(body.gameObject, Player);
-            Player.Probe.gameObject.SetActive(false);
+            Player.Probe.Body.SetActive(false);
             return body;
         }
 

--- a/QSB/TransformSync/PlayerTransformSync.cs
+++ b/QSB/TransformSync/PlayerTransformSync.cs
@@ -14,18 +14,11 @@ namespace QSB.TransformSync
             LocalInstance = this;
         }
 
-        protected override uint GetAttachedNetId()
-        {
-            /*
-            Players are stored in PlayerRegistry using a specific ID. This ID has to remain the same
-            for all components of a player, so I've chosen to used the netId of PlayerTransformSync.
-            This is minus 0 so all transformsyncs follow the same template.
-            */
-            return netId.Value - 0;
-        }
+        protected override uint PlayerId => netId.Value;
 
         private Transform GetPlayerModel()
         {
+            Player.PlayerTransformSync = this;
             return Locator.GetPlayerTransform().Find("Traveller_HEA_Player_v2");
         }
 
@@ -37,7 +30,7 @@ namespace QSB.TransformSync
 
             GetComponent<AnimationSync>().InitLocal(body);
 
-            PlayerRegistry.GetPlayer(GetAttachedNetId()).Body = body.gameObject;
+            Player.Body = body.gameObject;
 
             return body;
         }
@@ -51,16 +44,16 @@ namespace QSB.TransformSync
             GetComponent<AnimationSync>().InitRemote(body);
 
             var marker = body.gameObject.AddComponent<PlayerHUDMarker>();
-            marker.SetId(GetAttachedNetId());
+            marker.SetId(PlayerId);
 
-            PlayerRegistry.GetPlayer(GetAttachedNetId()).Body = body.gameObject;
+            Player.Body = body.gameObject;
 
             return body;
         }
 
         protected override bool IsReady()
         {
-            return Locator.GetPlayerTransform() != null && PlayerRegistry.PlayerExists(GetAttachedNetId());
+            return Locator.GetPlayerTransform() != null && Player != null;
         }
     }
 }

--- a/QSB/TransformSync/PlayerTransformSync.cs
+++ b/QSB/TransformSync/PlayerTransformSync.cs
@@ -58,11 +58,6 @@ namespace QSB.TransformSync
             return body;
         }
 
-        protected override Vector3? Override()
-        {
-            return null;
-        }
-
         protected override bool IsReady()
         {
             return Locator.GetPlayerTransform() != null && PlayerRegistry.PlayerExists(GetAttachedNetId());

--- a/QSB/TransformSync/ShipTransformSync.cs
+++ b/QSB/TransformSync/ShipTransformSync.cs
@@ -11,17 +11,7 @@ namespace QSB.TransformSync
             LocalInstance = this;
         }
 
-        protected override uint GetAttachedNetId()
-        {
-            /*
-            Players are stored in PlayerRegistry using a specific ID. This ID has to remain the same
-            for all components of a player, so I've chosen to used the netId of PlayerTransformSync.
-            Since every networkbehaviour has it's own ascending netId, and we know that PlayerCameraSync
-            is the 2nd network transform to be loaded (After PlayerTransformSync), we can just
-            minus 1 from ShipTransformSync's netId to get PlayerTransformSyncs's netId.
-            */
-            return netId.Value - 1;
-        }
+        protected override uint PlayerId => netId.Value - 1;
 
         private Transform GetShipModel()
         {

--- a/QSB/TransformSync/ShipTransformSync.cs
+++ b/QSB/TransformSync/ShipTransformSync.cs
@@ -61,11 +61,6 @@ namespace QSB.TransformSync
             return remoteTransform;
         }
 
-        protected override Vector3? Override()
-        {
-            return null;
-        }
-
         protected override bool IsReady()
         {
             return GetShipModel() != null;

--- a/QSB/TransformSync/TransformSync.cs
+++ b/QSB/TransformSync/TransformSync.cs
@@ -115,7 +115,14 @@ namespace QSB.TransformSync
 
         public void TeleportTo(Vector3 position, Transform referenceTransform)
         {
-            SyncedTransform.position = position;
+            if (hasAuthority)
+            {
+                transform.position = position;
+            }
+            else
+            {
+                SyncedTransform.localPosition = position;
+            }
             ReferenceTransform = referenceTransform;
             _positionSmoothVelocity = Vector3.zero;
         }

--- a/QSB/TransformSync/TransformSync.cs
+++ b/QSB/TransformSync/TransformSync.cs
@@ -25,7 +25,7 @@ namespace QSB.TransformSync
         private bool _isSectorSetUp;
         private Vector3 _positionSmoothVelocity;
         private Quaternion _rotationSmoothVelocity;
-        
+
         protected virtual void Awake()
         {
             PlayerRegistry.TransformSyncs.Add(this);

--- a/QSB/TransformSync/TransformSync.cs
+++ b/QSB/TransformSync/TransformSync.cs
@@ -120,7 +120,7 @@ namespace QSB.TransformSync
 
         public void TeleportToPosition(Vector3 position, Transform referenceTransform)
         {
-            SyncedTransform.position = position;
+            SyncedTransform.localPosition = position;
             ReferenceTransform = referenceTransform;
             _positionSmoothVelocity = Vector3.zero;
         }

--- a/QSB/TransformSync/TransformSync.cs
+++ b/QSB/TransformSync/TransformSync.cs
@@ -113,14 +113,9 @@ namespace QSB.TransformSync
             }
         }
 
-        public void TeleportToPlayer(PlayerInfo player)
+        public void TeleportTo(Vector3 position, Transform referenceTransform)
         {
-            TeleportToPosition(player.Position, player.ReferenceTransform);
-        }
-
-        public void TeleportToPosition(Vector3 position, Transform referenceTransform)
-        {
-            SyncedTransform.localPosition = position;
+            SyncedTransform.position = position;
             ReferenceTransform = referenceTransform;
             _positionSmoothVelocity = Vector3.zero;
         }

--- a/QSB/TransformSync/TransformSync.cs
+++ b/QSB/TransformSync/TransformSync.cs
@@ -121,7 +121,7 @@ namespace QSB.TransformSync
             }
             else
             {
-                SyncedTransform.localPosition = position;
+                SyncedTransform.localPosition = referenceTransform.InverseTransformPoint(position);
             }
             ReferenceTransform = referenceTransform;
             _positionSmoothVelocity = Vector3.zero;

--- a/QSB/TransformSync/TransformSync.cs
+++ b/QSB/TransformSync/TransformSync.cs
@@ -15,10 +15,17 @@ namespace QSB.TransformSync
         public Transform SyncedTransform { get; private set; }
         public Transform ReferenceTransform { get; set; }
 
+        public PlayerInfo Player => PlayerRegistry.GetPlayer(PlayerId);
+
+        protected abstract Transform InitLocalTransform();
+        protected abstract Transform InitRemoteTransform();
+        protected abstract bool IsReady();
+        protected abstract uint PlayerId { get; }
+
         private bool _isSectorSetUp;
         private Vector3 _positionSmoothVelocity;
         private Quaternion _rotationSmoothVelocity;
-
+        
         protected virtual void Awake()
         {
             PlayerRegistry.TransformSyncs.Add(this);
@@ -33,11 +40,6 @@ namespace QSB.TransformSync
                 Reset();
             }
         }
-
-        protected abstract Transform InitLocalTransform();
-        protected abstract Transform InitRemoteTransform();
-        protected abstract bool IsReady();
-        protected abstract uint GetAttachedNetId();
 
         protected void Init()
         {
@@ -109,6 +111,18 @@ namespace QSB.TransformSync
                     SyncedTransform.localRotation = QuaternionHelper.SmoothDamp(SyncedTransform.localRotation, transform.rotation, ref _rotationSmoothVelocity, Time.deltaTime);
                 }
             }
+        }
+
+        public void TeleportToPlayer(PlayerInfo player)
+        {
+            TeleportToPosition(player.Position, player.ReferenceTransform);
+        }
+
+        public void TeleportToPosition(Vector3 position, Transform referenceTransform)
+        {
+            SyncedTransform.position = position;
+            ReferenceTransform = referenceTransform;
+            _positionSmoothVelocity = Vector3.zero;
         }
 
     }

--- a/QSB/TransformSync/TransformSync.cs
+++ b/QSB/TransformSync/TransformSync.cs
@@ -38,7 +38,6 @@ namespace QSB.TransformSync
         protected abstract Transform InitRemoteTransform();
         protected abstract bool IsReady();
         protected abstract uint GetAttachedNetId();
-        protected abstract Vector3? Override();
 
         protected void Init()
         {
@@ -90,11 +89,6 @@ namespace QSB.TransformSync
             {
                 transform.position = ReferenceTransform.InverseTransformPoint(SyncedTransform.position);
                 transform.rotation = ReferenceTransform.InverseTransformRotation(SyncedTransform.rotation);
-
-                if (Override().HasValue)
-                {
-                    transform.position = ReferenceTransform.InverseTransformPoint(Override().Value);
-                }
             }
             else // If this script is attached to any other body, eg the representations of other players
             {
@@ -113,11 +107,6 @@ namespace QSB.TransformSync
 
                     SyncedTransform.localPosition = Vector3.SmoothDamp(SyncedTransform.localPosition, transform.position, ref _positionSmoothVelocity, SmoothTime);
                     SyncedTransform.localRotation = QuaternionHelper.SmoothDamp(SyncedTransform.localRotation, transform.rotation, ref _rotationSmoothVelocity, Time.deltaTime);
-
-                    if (Override().HasValue)
-                    {
-                        SyncedTransform.localPosition = SyncedTransform.InverseTransformPoint(Override().Value);
-                    }
                 }
             }
         }


### PR DESCRIPTION
* `GetAttachedId()` -> `PlayerId` (on TransformSync's)
* `PlayerRegistry.GetPlayer(GetAttachedId())` -> `Player` (on TransformSync's)
* Fixed teleportation - all TransforSyncs now have `TeleportTo...` methods that work well enough